### PR TITLE
Add "Join our Newsletter" link to footer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'jekyll', '3.8.5'
+gem 'jekyll-redirect-from'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,64 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    colorator (1.1.0)
+    concurrent-ruby (1.1.5)
+    em-websocket (0.5.1)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
+    eventmachine (1.2.7)
+    ffi (1.11.1)
+    forwardable-extended (2.6.0)
+    http_parser.rb (0.6.0)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    jekyll (3.8.5)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 0.7)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 1.14)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (>= 1.7, < 4)
+      safe_yaml (~> 1.0)
+    jekyll-redirect-from (0.15.0)
+      jekyll (>= 3.3, < 5.0)
+    jekyll-sass-converter (1.5.2)
+      sass (~> 3.4)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    kramdown (1.17.0)
+    liquid (4.0.3)
+    listen (3.2.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.3.6)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (4.0.1)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
+    rouge (3.12.0)
+    safe_yaml (1.0.5)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll (= 3.8.5)
+  jekyll-redirect-from
+
+BUNDLED WITH
+   2.0.2

--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ Development
 This site is built with HTML, CSS, Javascript. It runs on [jekyll](http://jekyllrb.com/) and is hosted by [GitHub Pages](https://pages.github.com/).
 
 1. Create a fork of this project
-2. Clone the fork to your computer
-3. `cd codeforall.org` into the directory
-4. run `jekyll serve .` from the root of the project
-5. Open the site at http://localhost:4000
-6. You can now manipulate the files and refresh your browser to see the results
-7. When finished, commit your changes and push them to your fork
-8. Create a pull request
+1. Clone the fork to your computer
+1. `cd codeforall.org` into the directory
+1. Install Ruby (we recommend version `2.5.3`) and bundler (`gem install bundler`)
+1. Run `bundle install`
+1. run `jekyll serve .` from the root of the project
+1. Open the site at http://localhost:4000
+1. You can now manipulate the files and refresh your browser to see the results
+1. When finished, commit your changes and push them to your fork
+1. Create a pull request
 
 Resources
 -------

--- a/_data/links.json
+++ b/_data/links.json
@@ -1,6 +1,7 @@
 {
     "chat-with-us": "https://slack.codeforall.org/",
     "write-an-email": "mailto:contact@codeforall.org",
+    "join-our-newsletter": "https://codeforall.us19.list-manage.com/subscribe?u=5fe264cee446e49a5c4de7db0&id=f229d02267",
     "read-our-stories": "https://medium.com/code-for-all",
     "connect-with-us": "https://www.facebook.com/letscodeforall/",
     "tweet-us": "https://twitter.com/CodeforAll",

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,8 +5,8 @@
                 <div class="footer-mrg-left">
                     <a class="footer-link" href="{{ site.data.links.chat-with-us }}">
                         <span class="link-icon slack-link"></span>Chat with us</a>
-                    <a class="footer-link" href="{{ site.data.links.write-an-email }}">
-                        <span class="link-icon email-link"></span>Write us an email</a>
+                    <a class="footer-link" href="{{ site.data.links.join-our-newsletter }}">
+                        <span class="link-icon email-link"></span>Join our Newsletter</a>
                     <a class="footer-link" href="{{ site.data.links.read-our-stories }}">
                         <span class="link-icon m-link"></span>Read our stories</a>
                 </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
                     <a class="footer-link" href="{{ site.data.links.chat-with-us }}">
                         <span class="link-icon slack-link"></span>Chat with us</a>
                     <a class="footer-link" href="{{ site.data.links.join-our-newsletter }}">
-                        <span class="link-icon email-link"></span>Join our Newsletter</a>
+                        <span class="link-icon email-link"></span>Join our newsletter</a>
                     <a class="footer-link" href="{{ site.data.links.read-our-stories }}">
                         <span class="link-icon m-link"></span>Read our stories</a>
                 </div>


### PR DESCRIPTION
This commit also adds a Gemfile for easier development, in service of
adding a simple "Join our Newsletter" link to every page's footer.

I decided to replace the "write an email" option here because the "write
us an email" CTA is already in the "get involved" partial and right
above these links on most pages anyway.